### PR TITLE
CI Test PR

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,34 @@
+name: Build and test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 16.x] # 10.x from debian buster
+        php-version: [7.3, 7.4]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'yarn'
+    - name: Use PHP ${{ matrix.php-version }}
+      uses: shivammathur/setup-php@e02a1810e66ae357773a8f82626c7965d13ca75c # pinned 2.11.0
+      with:
+        php-version: ${{ matrix.php-version }}
+    - run: make build
+    - run: cp php/config-dist.php data/config.php
+    - run: GROCY_MODE=dev php -S localhost:8000 -t public &
+    - run: curl http://localhost:8000/ # setup database
+    - run: curl http://localhost:8000/api/stock | jq | grep "best_before_date"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,26 @@
+name: Check PHP formatting
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version: [7.4]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use PHP ${{ matrix.php-version }}
+      uses: shivammathur/setup-php@e02a1810e66ae357773a8f82626c7965d13ca75c # pinned 2.11.0
+      with:
+        php-version: ${{ matrix.php-version }}
+    - run: mkdir --parents tools/php-cs-fixer
+    - run: composer require --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer
+    - run: tools/php-cs-fixer/vendor/bin/php-cs-fixer fix php --verbose --dry-run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: Lint JavaScript and check formatting
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'yarn'
+    - name: Use PHP ${{ matrix.php-version }}
+      uses: shivammathur/setup-php@e02a1810e66ae357773a8f82626c7965d13ca75c # pinned 2.11.0
+      with:
+        php-version: ${{ matrix.php-version }}
+    - run: yarn
+    - run: yarn eslint js/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,9 +22,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-    - name: Use PHP ${{ matrix.php-version }}
-      uses: shivammathur/setup-php@e02a1810e66ae357773a8f82626c7965d13ca75c # pinned 2.11.0
-      with:
-        php-version: ${{ matrix.php-version }}
     - run: yarn
     - run: yarn eslint js/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+        php-version: [7.3]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - name: Use PHP ${{ matrix.php-version }}
+        uses: shivammathur/setup-php@e02a1810e66ae357773a8f82626c7965d13ca75c # pinned 2.11.0
+        with:
+          php-version: ${{ matrix.php-version }}
+      - run: make release
+      - name: Release
+        uses: softprops/action-gh-release@9729932bfb75c05ad1f6e3a729294e05abaa7001 # 2021-05-03
+        with:
+          files: release/not-grocy-*.tar.xz
+          # body_path: changelog/${{ github.ref }}.md
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,19 +1,16 @@
 <?php
 
-return PhpCsFixer\Config::create()
-    ->setRules(array(
+$config = new PhpCsFixer\Config();
+return $config->setRules(array(
         '@PSR2' => true,
         'array_indentation' => true,
         'array_syntax' => array('syntax' => 'short'),
         'combine_consecutive_unsets' => true,
-        'method_separation' => true,
-        'no_multiline_whitespace_before_semicolons' => true,
+        'phpdoc_separation' => true,
+        'multiline_whitespace_before_semicolons' => false,
         'single_quote' => true,
 
-        'binary_operator_spaces' => array(
-            'align_double_arrow' => false,
-            'align_equals' => false,
-        ),
+        
         // 'blank_line_after_opening_tag' => true,
         // 'blank_line_before_return' => true,
         'braces' => array(
@@ -27,7 +24,6 @@ return PhpCsFixer\Config::create()
         'concat_space' => array('spacing' => 'one'),
         'declare_equal_normalize' => true,
         'function_typehint_space' => true,
-        'hash_to_slash_comment' => true,
         'include' => true,
         'lowercase_cast' => true,
         // 'native_function_casing' => true,
@@ -37,13 +33,6 @@ return PhpCsFixer\Config::create()
         // 'no_empty_comment' => true,
         // 'no_empty_phpdoc' => true,
         // 'no_empty_statement' => true,
-        'no_extra_consecutive_blank_lines' => array(
-            'extra',
-            'parenthesis_brace_block',
-            'square_brace_block',
-            'throw',
-            'use',
-        ),
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         // 'no_mixed_echo_print' => array('use' => 'echo'),
@@ -93,5 +82,4 @@ return PhpCsFixer\Config::create()
         'whitespace_after_comma_in_array' => true,
     ))
     ->setIndent("\t")
-    ->setLineEnding("\n")
-;
+    ->setLineEnding("\n");

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ release:
 .PHONY=pack
 pack: publish manifest
 	mkdir -p release
-	tar cvfJ release/not-grocy-$(shell git describe --tags).tar.xz \
+	tar cfJ release/not-grocy-$(shell git describe --tags).tar.xz \
 		changelog \
 		controllers \
 		data/.htaccess \

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,6 @@ pack: publish manifest
 # only permit to build a release zip from an actual commit (which will be referenced in version.json)
 .PHONY=manifest
 manifest:
-	git add version.json
 	git update-index --refresh 
 	git diff-index --quiet HEAD --
 	php -r 'echo json_encode(["Version" => trim(`git describe --tags`), "ReleaseDate" => date("Y-m-d")]);' > version.json

--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,7 @@ pack: publish manifest
 # only permit to build a release zip from an actual commit (which will be referenced in version.json)
 .PHONY=manifest
 manifest:
+	git add version.json
 	git update-index --refresh 
 	git diff-index --quiet HEAD --
 	php -r 'echo json_encode(["Version" => trim(`git describe --tags`), "ReleaseDate" => date("Y-m-d")]);' > version.json

--- a/Makefile
+++ b/Makefile
@@ -219,9 +219,9 @@ pack: publish manifest
 		public \
 		services \
 		vendor \
-		views \
-		app.php \
-		config-dist.php \
+		php/Views \
+		php/app.php \
+		php/config-dist.php \
 		grocy.openapi.json \
 		php/routes.php \
 		version.json

--- a/Makefile
+++ b/Makefile
@@ -209,13 +209,13 @@ pack: publish manifest
 	mkdir -p release
 	tar cfJ release/not-grocy-$(shell git describe --tags).tar.xz \
 		changelog \
-		controllers \
+		php/Controllers \
 		data/.htaccess \
 		data/plugins \
-		helpers \
+		php/Helpers \
 		localization \
-		middleware \
-		migrations \
+		php/Middleware \
+		php/Migrations \
 		public \
 		services \
 		vendor \

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ pack: publish manifest
 		app.php \
 		config-dist.php \
 		grocy.openapi.json \
-		routes.php \
+		php/routes.php \
 		version.json
 
 # this will error if the working tree is dirty (git diff-index will return a non-zero status code)

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ pack: publish manifest
 		php/Middleware \
 		php/Migrations \
 		public \
-		services \
+		php/Services \
 		vendor \
 		php/Views \
 		php/app.php \

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "A fork of grocy, the household ERP management – but faster, better, harder, stronger.",
 	"license": "MIT",
 	"require": {
-		"php": ">=7.4",
+		"php": ">=7.3",
 		"eluceo/ical": "^0.16.0",
 		"erusev/parsedown": "^1.7",
 		"ezyang/htmlpurifier": "^4.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c44e942dbadc346f2a1f54b769bcd67e",
+    "content-hash": "eb66db391921c0dee65ad4153e7e04a1",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -3402,7 +3402,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4"
+        "php": ">=7.3"
     },
     "platform-dev": [],
     "plugin-api-version": "2.1.0"


### PR DESCRIPTION
The changelog files should have a predictable location / we can glob them.

Maybe the release should also run the tests etc again to ensure we don't release a broken main accidentially.


 npx eslint --init 
removed